### PR TITLE
Assign GFv1 catchment boundaries for segments with missing HRU's

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ _targets/
 #All output
 */out/*
 !2_process/out/GFv1_NHDv2_xwalk.csv
+!2_process/out/GFv1_catchments_edited.gpkg
 */tmp/*
 scratch/* 
 

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ _targets/
 */out/*
 !2_process/out/GFv1_NHDv2_xwalk.csv
 */tmp/*
+scratch/* 
 
 #R files
 # History files

--- a/2_process.R
+++ b/2_process.R
@@ -44,7 +44,7 @@ p2_targets_list <- list(
   # Save processed GFv1 catchments as a geopackage
   tar_target(
     p2_GFv1_catchments_edited_gpkg,
-    st_write(p2_GFv1_catchments_edited_sf, 
+    sf::st_write(p2_GFv1_catchments_edited_sf, 
              dsn = "2_process/out/GFv1_catchments_edited.gpkg", 
              layer = "GFv1_catchments_edited", 
              driver = "gpkg",

--- a/2_process.R
+++ b/2_process.R
@@ -1,6 +1,7 @@
 source("2_process/src/pair_nhd_reaches.R")
 source("2_process/src/pair_nhd_catchments.R")
 source("2_process/src/create_GFv1_NHDv2_xwalk.R")
+source("2_process/src/munge_GFv1_catchments.R")
 source("2_process/src/write_data.R")
 source("2_process/src/write_ind_files.R")
 
@@ -30,6 +31,14 @@ p2_targets_list <- list(
       select(PRMS_segid, comid_cat) %>% 
       tidyr::separate_rows(comid_cat,sep=";") %>% 
       rename(COMID = comid_cat)
+  ),
+  
+  # Process catchments so that every PRMS segment has >= 1 corresponding HRU; In addition,
+  # adjust catchments for 3 segments that were split in `delaware-model-prep` pipeline
+  # https://github.com/USGS-R/delaware-model-prep
+  tar_target(
+    p2_GFv1_catchments_edited_sf,
+    munge_GFv1_catchments(p1_GFv1_reaches_sf,p1_GFv1_catchments_sf,p2_drb_comids_all_tribs,crs_out = 4326)
   ),
   
   # Create and save indicator file

--- a/2_process.R
+++ b/2_process.R
@@ -38,7 +38,7 @@ p2_targets_list <- list(
   # https://github.com/USGS-R/delaware-model-prep
   tar_target(
     p2_GFv1_catchments_edited_sf,
-    munge_GFv1_catchments(p1_GFv1_reaches_sf,p1_GFv1_catchments_sf,p2_drb_comids_all_tribs,crs_out = 4326)
+    munge_GFv1_catchments(p1_GFv1_reaches_sf,p1_GFv1_catchments_sf,p2_drb_comids_all_tribs,GFv1_segs_split,crs_out = 4326)
   ),
   
   # Save processed GFv1 catchments as a geopackage

--- a/2_process.R
+++ b/2_process.R
@@ -23,6 +23,15 @@ p2_targets_list <- list(
     format = "file"
   ),
   
+  # Reshape GFv1-NHDv2 xwalk table to return all COMIDs that drain to each PRMS segment
+  tar_target(
+    p2_drb_comids_all_tribs, 
+    p2_prms_nhdv2_xwalk %>%
+      select(PRMS_segid, comid_cat) %>% 
+      tidyr::separate_rows(comid_cat,sep=";") %>% 
+      rename(COMID = comid_cat)
+  ),
+  
   # Create and save indicator file
   # argument force_dep must contain name of an upstream target to force dependencies
   # and build this target when a log file already exists

--- a/2_process.R
+++ b/2_process.R
@@ -41,6 +41,18 @@ p2_targets_list <- list(
     munge_GFv1_catchments(p1_GFv1_reaches_sf,p1_GFv1_catchments_sf,p2_drb_comids_all_tribs,crs_out = 4326)
   ),
   
+  # Save processed GFv1 catchments as a geopackage
+  tar_target(
+    p2_GFv1_catchments_edited_gpkg,
+    st_write(p2_GFv1_catchments_edited_sf, 
+             dsn = "2_process/out/GFv1_catchments_edited.gpkg", 
+             layer = "GFv1_catchments_edited", 
+             driver = "gpkg",
+             quiet = TRUE,
+             # overwrite layer if already exists
+             append = FALSE)
+  ),
+  
   # Create and save indicator file
   # argument force_dep must contain name of an upstream target to force dependencies
   # and build this target when a log file already exists

--- a/2_process.R
+++ b/2_process.R
@@ -44,13 +44,14 @@ p2_targets_list <- list(
   # Save processed GFv1 catchments as a geopackage
   tar_target(
     p2_GFv1_catchments_edited_gpkg,
-    sf::st_write(p2_GFv1_catchments_edited_sf, 
+    write_sf(p2_GFv1_catchments_edited_sf,
              dsn = "2_process/out/GFv1_catchments_edited.gpkg", 
              layer = "GFv1_catchments_edited", 
              driver = "gpkg",
              quiet = TRUE,
              # overwrite layer if already exists
-             append = FALSE)
+             append = FALSE),
+    format = "file"
   ),
   
   # Create and save indicator file

--- a/2_process/src/munge_GFv1_catchments.R
+++ b/2_process/src/munge_GFv1_catchments.R
@@ -54,9 +54,9 @@ return_nhdv2_cat_shps <- function(prms_line,segs_w_comids){
   # Use nhdplusTools to retrieve the catchment polygons for COMIDs of interest
   nhd_cats_sf <- nhdplusTools::get_nhdplus(comid = c(nhd_cats$COMID),realization = "catchment",t_srs = 5070) %>%
     # dissolve boundaries between individual NHDv2 catchments
-    st_union() %>%
+    sf::st_union() %>%
     # convert back to sf data.frame object and add the segment ID
-    st_as_sf() %>%
+    sf::st_as_sf() %>%
     mutate(PRMS_segid = unique(prms_line$subsegid)) %>%
     rename(geometry = x)
   
@@ -125,14 +125,14 @@ munge_GFv1_catchments <- function(prms_lines,prms_hrus,segs_w_comids,crs_out = 4
         mutate(hru_segment = prms_line$subsegid,
                hru_id = NA) %>%
         select(PRMS_segid,hru_segment,hru_id,geometry) %>%
-        st_transform(.,crs_out)
+        sf::st_transform(.,crs_out)
     } else {
       cat <- prms_hrus %>%
         filter(hru_segment == prms_line$hru_segment) %>%
         mutate(PRMS_segid = prms_line$subsegid) %>%
         select(PRMS_segid,hru_segment,hru_id) %>%
         rename(geometry = Shape) %>%
-        st_transform(.,crs_out)
+        sf::st_transform(.,crs_out)
     }
     
     catchments_ls[[i]] <- cat

--- a/2_process/src/munge_GFv1_catchments.R
+++ b/2_process/src/munge_GFv1_catchments.R
@@ -128,14 +128,15 @@ munge_GFv1_catchments <- function(prms_lines,prms_hrus,segs_w_comids,segs_split,
       cat <- prms_splitsegs %>%
         filter(PRMS_segid == prms_line$subsegid) %>%
         mutate(hru_segment = prms_line$subsegid,
-               hru_id = NA) %>%
-        select(PRMS_segid,hru_segment,hru_id,geometry) 
+               hru_id = NA,
+               hru_area_m2 = as.numeric(sf::st_area(.))) %>%
+        select(PRMS_segid,hru_segment,hru_id,hru_area_m2)
     } else {
       cat <- prms_hrus %>%
         filter(hru_segment == prms_line$hru_segment) %>%
         mutate(PRMS_segid = prms_line$subsegid) %>%
-        select(PRMS_segid,hru_segment,hru_id) %>%
-        rename(geometry = Shape) 
+        select(PRMS_segid,hru_segment,hru_id,Shape_Area) %>%
+        rename(geometry = Shape, hru_area_m2 = Shape_Area) 
     }
     
     # Transform edited catchments to user-specified coordinate reference system

--- a/2_process/src/munge_GFv1_catchments.R
+++ b/2_process/src/munge_GFv1_catchments.R
@@ -88,7 +88,9 @@ munge_GFv1_catchments <- function(prms_lines,prms_hrus,segs_w_comids,segs_split,
     split(.,.$subsegid) %>%
     # For each PRMS segment, find the HRU with the greatest overlap and add as an attribute
     lapply(.,function(x){
-      x$hru_segment <- find_intersecting_hru(x,prms_hrus)
+      x$hru_segment <- ifelse(x$subsegseg %in% prms_hrus$hru_segment,
+                              x$subsegseg,
+                              find_intersecting_hru(x,prms_hrus))
       return(x)
     }) %>%
     # Reformat list into a data frame with one row per PRMS segment

--- a/2_process/src/munge_GFv1_catchments.R
+++ b/2_process/src/munge_GFv1_catchments.R
@@ -1,0 +1,142 @@
+find_intersecting_hru <- function(prms_line,prms_hrus){
+  #' 
+  #' @description This function finds all of the HRU polygons that intersect a
+  #' PRMS segment, and returns the HRU ID (i.e., hru_segment) that has the
+  #' greatest percent of overlap with the PRMS segment
+  #' 
+  #' @param prms_line sf object containing one PRMS river segment of interest
+  #' prms_line must contain variables subsegid and geometry
+  #' @param prms_hrus sf (multi)polygon containing the HRU's from the NHGFv1
+  #
+  
+  # Transform PRMS segment and HRU's into a consistent projection
+  # using Albers Equal Area Conic CONUS
+  prms_line_proj <- sf::st_transform(prms_line, 5070)
+  prms_hrus_proj <- sf::st_transform(prms_hrus, 5070)
+  
+  # Calculate the length of prms_line and add as an attribute
+  prms_line_proj$length = sf::st_length(prms_line_proj$geometry)
+  
+  # Find which the intersections between HRU polygons and prms_line
+  # suppress warnings that "attribute variables are assumed to be spatially constant
+  # throughout all geometries"
+  intsct_hrus <- sf::st_intersection(prms_line_proj,prms_hrus_proj) %>%
+    suppressWarnings()
+  
+  # Calculate percent of overlap between each HRU and prms_line
+  intsct_hrus$length_percent = 100 * (sf::st_length(intsct_hrus)/intsct_hrus$length)
+  
+  # Return attribute `hru_segment` for the HRU with greatest overlap with prms_line
+  hru_segment <- intsct_hrus$hru_segment[which.max(intsct_hrus$length_percent)]
+  
+  return(hru_segment)
+  
+}
+
+
+
+return_nhdv2_cat_shps <- function(prms_line,segs_w_comids){
+  #' 
+  #' @description This function takes a data table of PRMS segment ID's and
+  #' its contributing NHDv2 tributary catchments and returns those catchments
+  #' as an sf object
+  #' 
+  #' @param prms_line sf object containing one PRMS river segment of interest
+  #' prms_line must contain variables subsegid and geometry
+  #' @param segs_w_comids data frame containing the PRMS segment ids and the contributing COMID's
+  #' segs_w_comids must contain variables PRMS_segid and COMID
+  #' 
+  
+  nhd_cats <- segs_w_comids %>%
+    filter(PRMS_segid == prms_line$subsegid)
+  
+  nhd_cats_sf <- nhdplusTools::get_nhdplus(comid = c(nhd_cats$COMID),realization = "catchment",t_srs = 5070) %>%
+    # dissolved boundaries between individual NHDv2 catchments
+    st_union() %>%
+    # convert back to sf data.frame object and add the segment ID
+    st_as_sf() %>%
+    mutate(PRMS_segid = unique(prms_line$subsegid)) %>%
+    rename(geometry = x)
+  
+  return(nhd_cats_sf)
+  
+}
+
+
+
+munge_GFv1_catchments <- function(prms_lines,prms_hrus,segs_w_comids,crs_out = 4326){
+  #' 
+  #' @description This function munges the PRMS HRU's (~ the PRMS catchments) so that every
+  #' PRMS segment in the Delaware River Basin has at least one corresponding HRU and so that 
+  #' the catchment boundaries are adjusted for 3 NHGFv1 segments that were split in the 
+  #' `delaware-model-prep` pipeline: segid's 3_1, 3_2, 8_1, 8_2, 51_1, 51_2 
+  #' (https://github.com/USGS-R/delaware-model-prep) 
+  #' 
+  #' @param prms_lines sf object containing the PRMS river segments for the DRB
+  #' prms_lines must contain variables subsegid and geometry
+  #' @param segs_w_comids data frame containing the PRMS segment ids and the contributing COMID's
+  #' segs_w_comids must contain variables PRMS_segid and COMID
+  #' @param prms_hrus sf (multi)polygon containing the HRU's from the NHGFv1
+  #' @param crs_out numeric EPSG code indicating desired crs. Defaults to EPSG: 4326, WGS84.
+  #
+  
+  # 1. Fill PRMS lines data frame so that every segment has a value for the attribute
+  # `hru_segment`, which can be used as a key to join each segment to its corresponding HRU polygons.
+  prms_hrus_filled <- prms_lines %>%
+    # Transform prms_lines into a list with a data frame for each PRMS segment (represented by a unique subsegid) 
+    split(.,.$subsegid) %>%
+    # For each PRMS segment, find the HRU with the greatest overlap and add as an attribute
+    lapply(.,function(x){
+      x$hru_segment <- find_intersecting_hru(x,prms_hrus)
+      return(x)
+    }) %>%
+    # Reformat list into a data frame with one row per PRMS segment
+    bind_rows()
+  
+  # 2. For select segments, redefine the catchment polygon using the contributing NHDv2 catchments
+  segs_split <- c("3_1","3_2","8_1","8_2","51_1","51_2")
+  
+  prms_splitsegs <- prms_hrus_filled %>%
+    # Filter PRMS segments to only include select segments that require special handling
+    filter(subsegid %in% segs_split) %>%
+    # Transform PRMS segments into a list with a data frame for each segment
+    split(.,.$subsegid) %>%
+    # For each segment requiring special handling, return the polygon that represents the catchment area
+    lapply(.,return_nhdv2_cat_shps, segs_w_comids = segs_w_comids) %>%
+    # Reformat list into a data frame with one row per PRMS segment
+    bind_rows()
+  
+  # 3. Concatenate munged catchment polygons
+  catchments_ls <- list()
+  
+  # Fill empty list with appropriate catchments
+  for(i in seq_along(prms_hrus_filled$subsegid)){
+    
+    prms_line <- prms_hrus_filled[i,]
+    
+    if(prms_line$subsegid %in% segs_split){
+      cat <- prms_splitsegs %>%
+        filter(PRMS_segid == prms_line$subsegid) %>%
+        mutate(hru_segment = prms_line$subsegid,
+               hru_id = NA) %>%
+        select(PRMS_segid,hru_segment,hru_id,geometry) %>%
+        st_transform(.,crs_out)
+    } else {
+      cat <- prms_hrus %>%
+        filter(hru_segment == prms_line$hru_segment) %>%
+        mutate(PRMS_segid = prms_line$subsegid) %>%
+        select(PRMS_segid,hru_segment,hru_id) %>%
+        rename(geometry = Shape) %>%
+        st_transform(.,crs_out)
+    }
+    
+    catchments_ls[[i]] <- cat
+    
+  }
+  
+  catchments_proc <- do.call("rbind",catchments_ls)
+
+  return(catchments_proc)
+  
+}
+

--- a/2_process/src/munge_GFv1_catchments.R
+++ b/2_process/src/munge_GFv1_catchments.R
@@ -17,15 +17,15 @@ find_intersecting_hru <- function(prms_line,prms_hrus){
   # Return the intersection between prms_line and HRU polygons 
   # suppress warnings that "attribute variables are assumed to be spatially constant
   # throughout all geometries"
-  intsct_hrus <- sf::st_intersection(prms_line_proj,prms_hrus_proj) %>%
+  prms_line_intsct_hrus <- sf::st_intersection(prms_line_proj,prms_hrus_proj) %>%
     suppressWarnings()
   
   # Calculate percent of overlap between each HRU and prms_line, where attribute
   # `subseglen` is the length of the segment in meters
-  intsct_hrus$length_percent = 100 * (sf::st_length(intsct_hrus)/intsct_hrus$subseglen)
+  prms_line_intsct_hrus$length_percent = 100 * (sf::st_length(prms_line_intsct_hrus)/prms_line_intsct_hrus$subseglen)
   
   # Return attribute `hru_segment` for the HRU that has the greatest overlap with prms_line
-  hru_segment <- intsct_hrus$hru_segment[which.max(intsct_hrus$length_percent)]
+  hru_segment <- prms_line_intsct_hrus$hru_segment[which.max(prms_line_intsct_hrus$length_percent)]
   
   return(hru_segment)
   

--- a/2_process/src/munge_GFv1_catchments.R
+++ b/2_process/src/munge_GFv1_catchments.R
@@ -66,19 +66,20 @@ return_nhdv2_cat_shps <- function(prms_line,segs_w_comids){
 
 
 
-munge_GFv1_catchments <- function(prms_lines,prms_hrus,segs_w_comids,crs_out = 4326){
+munge_GFv1_catchments <- function(prms_lines,prms_hrus,segs_w_comids,segs_split,crs_out = 4326){
   #' 
   #' @description This function munges the PRMS HRU's (~ the PRMS catchments) so that every
   #' PRMS segment in the Delaware River Basin has at least one corresponding HRU and so that 
-  #' the catchment boundaries are adjusted for 3 NHGFv1 segments that were split in the 
-  #' `delaware-model-prep` pipeline: segid's 3_1, 3_2, 8_1, 8_2, 51_1, 51_2 
-  #' (https://github.com/USGS-R/delaware-model-prep) 
+  #' the catchment boundaries are adjusted for NHGFv1 segments that were split in the 
+  #' `delaware-model-prep` pipeline (https://github.com/USGS-R/delaware-model-prep) 
   #' 
   #' @param prms_lines sf object containing the PRMS river segments for the DRB
   #' prms_lines must contain variables subsegid and geometry
   #' @param segs_w_comids data frame containing the PRMS segment ids and the contributing COMID's
   #' segs_w_comids must contain variables PRMS_segid and COMID
   #' @param prms_hrus sf (multi)polygon containing the HRU's from the NHGFv1
+  #' @param segs_split character vector indicating the PRMS_segid of the segments that were split in 
+  #' the delaware-model-prep pipeline
   #' @param crs_out numeric EPSG code indicating desired crs. Defaults to EPSG: 4326, WGS84.
   #
   
@@ -96,8 +97,6 @@ munge_GFv1_catchments <- function(prms_lines,prms_hrus,segs_w_comids,crs_out = 4
     bind_rows()
   
   # 2. For select segments, redefine the catchment polygon using the contributing NHDv2 catchments
-  segs_split <- c("3_1","3_2","8_1","8_2","51_1","51_2")
-  
   prms_splitsegs <- prms_hrus_filled %>%
     # Filter PRMS segments to only include select segments that require special handling
     filter(subsegid %in% segs_split) %>%

--- a/2_process/src/munge_GFv1_catchments.R
+++ b/2_process/src/munge_GFv1_catchments.R
@@ -13,18 +13,16 @@ find_intersecting_hru <- function(prms_line,prms_hrus){
   # using Albers Equal Area Conic CONUS
   prms_line_proj <- sf::st_transform(prms_line, 5070)
   prms_hrus_proj <- sf::st_transform(prms_hrus, 5070)
-  
-  # Calculate the length of prms_line and add as an attribute
-  prms_line_proj$length = sf::st_length(prms_line_proj$geometry)
-  
+
   # Return the intersection between prms_line and HRU polygons 
   # suppress warnings that "attribute variables are assumed to be spatially constant
   # throughout all geometries"
   intsct_hrus <- sf::st_intersection(prms_line_proj,prms_hrus_proj) %>%
     suppressWarnings()
   
-  # Calculate percent of overlap between each HRU and prms_line
-  intsct_hrus$length_percent = 100 * (sf::st_length(intsct_hrus)/intsct_hrus$length)
+  # Calculate percent of overlap between each HRU and prms_line, where attribute
+  # `subseglen` is the length of the segment in meters
+  intsct_hrus$length_percent = 100 * (sf::st_length(intsct_hrus)/intsct_hrus$subseglen)
   
   # Return attribute `hru_segment` for the HRU that has the greatest overlap with prms_line
   hru_segment <- intsct_hrus$hru_segment[which.max(intsct_hrus$length_percent)]

--- a/2_process/src/write_data.R
+++ b/2_process/src/write_data.R
@@ -29,7 +29,7 @@ write_sf <- function(data_sf, dsn, layer, driver, quiet, append){
   #' be used; see ??st_write for more details
   #' @param quiet logical, suppress info; see ??st_write for more details
   #' @param append logical, if FALSE, overwrite layer if it already exists; 
-  #' see ??st_writefor more details
+  #' see ??st_write for more details
   #'
   
   sf::st_write(data_sf, 

--- a/2_process/src/write_data.R
+++ b/2_process/src/write_data.R
@@ -4,7 +4,43 @@ write_to_rds <- function(data, outfile){
   return(outfile)
 }
 
+
+
 write_to_csv <- function(data, outfile){
   readr::write_csv(data, file = outfile)
   return(outfile)
 }
+
+
+write_sf <- function(data_sf, dsn, layer, driver, quiet, append){
+  #' 
+  #' @description This function writes an sf object to a file or 
+  #' database. Uses same arguments as sf::st_write and returns
+  #' a character string indicating the file path, including location and 
+  #' path extension
+  #' 
+  #' @param data_sf sf object to write to file
+  #' @param dsn character string indicating the data source name; see 
+  #' ??st_write for more details
+  #' @param layer character string indicating the layer name; If layer 
+  #' is missing, the basename of dsn is taken; see ??st_write for more
+  #' details
+  #' @param driver character string indicating the name of the driver to
+  #' be used; see ??st_write for more details
+  #' @param quiet logical, suppress info; see ??st_write for more details
+  #' @param append logical, if FALSE, overwrite layer if it already exists; 
+  #' see ??st_writefor more details
+  #'
+  
+  sf::st_write(data_sf, 
+               dsn = dsn, 
+               layer = layer, 
+               driver = driver,
+               quiet = quiet,
+               append = append) 
+  
+  return(dsn)
+  
+}
+
+

--- a/_targets.R
+++ b/_targets.R
@@ -28,6 +28,11 @@ drb_huc8s <- c("02040101","02040102","02040103","02040104","02040105","02040106"
 drb_segs_spatial <- c("31_1","135_1","233_1","236_1","244_1","249_1","332_1","354_1","355_1","358_1","396_1","593_1","1256_1","2137_1",
                       "2138_1","2757_1","2758_1","2759_1","2765_1","2766_1","2767_1","2772_1","2797_1")
 
+# Define the PRMS segments that were split within the USGS-R/delaware-model-prep pipeline; these 
+# segments require special handling to return proper catchment areas in place of NHGFv1 HRUs
+GFv1_segs_split <- c("3_1","3_2","8_1","8_2","51_1","51_2")
+
+
 # Return the complete list of targets
 c(p1_targets_list, p2_targets_list)
 

--- a/drb-network-prep.Rproj
+++ b/drb-network-prep.Rproj
@@ -1,0 +1,13 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX


### PR DESCRIPTION
This PR addresses an issue raised in the [drb-inland-salinity-ml ](https://github.com/USGS-R/drb-inland-salinity-ml)pipeline (issue [60](https://github.com/USGS-R/drb-inland-salinity-ml/issues/60)):

- Nearly 10% of PRMS segments (n = 41) are missing a corresponding HRU(s) that represent the catchment boundaries. 
- In addition, there are 3 segments that were split as part of the [delaware-model-prep](https://github.com/USGS-R/delaware-model-prep) pipeline and so their catchment areas deviate from the areas represented by the NHGFv1 HRUs. 

The code changes here create two new targets, `p2_GFv1_catchments_edited_sf`, which represents the edited HRU polygons as an {sf} object, and `p2_GFv1_catchments_edited_gpkg`, which saves the edited HRU polygons as a geopackage. With the .gpkg file, the polygons can be read into R using:

```
> catchments_edited <- sf::st_read(dsn = "2_process/out/GFv1_catchments_edited.gpkg", layer = "GFv1_catchments_edited")
> head(catchments_edited)
Simple feature collection with 6 features and 3 fields
Geometry type: MULTIPOLYGON
Dimension:     XY
Bounding box:  xmin: -74.99227 ymin: 42.05568 xmax: -74.49867 ymax: 42.36679
Geodetic CRS:  WGS 84
  PRMS_segid hru_segment hru_id                           geom
1        1_1           1   4057 MULTIPOLYGON (((-74.5047 42...
2        1_1           1   4059 MULTIPOLYGON (((-74.51637 4...
3       10_1          10   3959 MULTIPOLYGON (((-74.95916 4...
4       10_1          10   3962 MULTIPOLYGON (((-74.96761 4...
5       11_1          11   3991 MULTIPOLYGON (((-74.71793 4...
6       11_1          11   4003 MULTIPOLYGON (((-74.72089 4...
> dim(catchments_edited)
[1] 867   4
> length(unique(catchments_edited$PRMS_segid))
[1] 459
> 
```

To address the issue of missing HRUs, the code changes here find the HRU's that intersect a given PRMS segment and then assign the HRU with maximum overlap as the HRU representative of that segment. For example, in the image below, PRMS segid 12_1 now gets assigned to the HRUs where the attribute `hru_segment == 7`. 

![intersecting-example](https://user-images.githubusercontent.com/8785034/156066747-5046f439-5f8f-4693-8c82-3e7234bff38a.png)

For the PRMS segments that were missing a corresponding HRU, the intersecting HRU's are likely not always representative of the land area that drains to that PRMS segment. However, we might make a simplifying assumption that certain attributes (e.g. area-normalized road salt application rates) are similar between the intersecting HRU and the 'proper' catchment that isn't represented. 

Note that because we assign an HRU(s) polygon to each PRMS segment, there are some HRUs that are duplicated within the edited catchments (`p2_GFv1_catchments_edited_sf`) as a result of this workflow.

To address the issue of splitting the HRU's for specific segments (PRMS segids 3_1; 3_2; 8_1; 8_2; 51_1; and 51_2), the functions here use the contributing NHDv2 catchment COMIDs identified in the GFv1-NHDv2 crosswalk table and retrieve the catchment polygons using the `nhdplusTools` package. The split polygons are shown for "3_1", "3_2", "8_1", and "8_2" below:

![drb-inset](https://user-images.githubusercontent.com/8785034/156067521-f40dd11e-115f-4fe0-a42f-da35c8faa595.png)

I'm requesting @jds485 for a cursory review of the code and @msleckman for a more in-depth review to make sure that the outputs here match what is expected for various downstream raster processing workflows (e.g. gridMET, others). Thanks!





