### PR TITLE
Change CRS used to build p2_GFv1_catchments_edited

### DIFF
--- a/2_process.R
+++ b/2_process.R
@@ -38,7 +38,7 @@ p2_targets_list <- list(
   # https://github.com/USGS-R/delaware-model-prep
   tar_target(
     p2_GFv1_catchments_edited_sf,
-    munge_GFv1_catchments(p1_GFv1_reaches_sf,p1_GFv1_catchments_sf,p2_drb_comids_all_tribs,GFv1_segs_split,crs_out = 4326)
+    munge_GFv1_catchments(p1_GFv1_reaches_sf,p1_GFv1_catchments_sf,p2_drb_comids_all_tribs,GFv1_segs_split,crs_out = 5070)
   ),
   
   # Save processed GFv1 catchments as a geopackage

--- a/2_process.R
+++ b/2_process.R
@@ -38,7 +38,12 @@ p2_targets_list <- list(
   # https://github.com/USGS-R/delaware-model-prep
   tar_target(
     p2_GFv1_catchments_edited_sf,
-    munge_GFv1_catchments(p1_GFv1_reaches_sf,p1_GFv1_catchments_sf,p2_drb_comids_all_tribs,GFv1_segs_split,crs_out = 5070)
+    munge_GFv1_catchments(prms_lines = p1_GFv1_reaches_sf,
+                          prms_hrus = p1_GFv1_catchments_sf,
+                          segs_w_comids = p2_drb_comids_all_tribs,
+                          segs_split = GFv1_segs_split,
+                          crs_out = 5070,
+                          verbose = TRUE)
   ),
   
   # Save processed GFv1 catchments as a geopackage


### PR DESCRIPTION
Addresses #3.

To build `p2_GFv1_catchments_edited` I originally specified `crs_out` as 4326 (WGS84). One polygon associated with PRMS_segid 3_1 is made not valid during the transformation to WGS84 (see #3). The same issue arises if I apply `nhdplusTools::get_nhdplus()` for the COMIDs that make up this catchment and request that the data be returned in WGS84, suggesting to me that the oddity with this polygon is not created by our code. 

Here I've opted to keep the polygons in a projected coordinate reference system (epsg 5070; Albers Equal Area Conic) that avoids issues with the 3_1 polygon becoming invalid and also more closely matches the format of the HRUs originally downloaded from ScienceBase. 

After making this change, I get:
```
> all(st_is_valid(p2_GFv1_catchments_edited_sf))
[1] TRUE
```
