### PR TITLE
Use national GF to build catchment polygons

### DIFF
--- a/2_process.R
+++ b/2_process.R
@@ -34,7 +34,7 @@ p2_targets_list <- list(
   ),
   
   # Process catchments so that every PRMS segment has >= 1 corresponding HRU; In addition,
-  # adjust catchments for 3 segments that were split in `delaware-model-prep` pipeline
+  # adjust catchments for 3 segments that were split in delaware-model-prep pipeline
   # https://github.com/USGS-R/delaware-model-prep
   tar_target(
     p2_GFv1_catchments_edited_sf,

--- a/2_process/src/munge_GFv1_catchments.R
+++ b/2_process/src/munge_GFv1_catchments.R
@@ -9,9 +9,12 @@ find_intersecting_hru <- function(prms_line,prms_hrus){
   #' @param prms_hrus sf (multi)polygon containing the HRU's from the NHGFv1
   #
   
-  # Transform PRMS segment and HRU's into a consistent projection
-  # using Albers Equal Area Conic CONUS
+  # Transform PRMS segment and HRU's into a consistent projection using Albers Equal
+  # Area Conic CONUS
   prms_line_proj <- sf::st_transform(prms_line, 5070) %>%
+    # add some small buffer (arbitrary, equal to 5m) so that we can identify the hru with
+    # the greatest overlap with prms_line using the intersected area between 
+    # prms_line_proj and prms_hrus_proj.
     sf::st_buffer(5) %>%
     select(subsegid, subsegseg, subseglen, fromsegs, toseg, tosubseg, segidnat)
   prms_hrus_proj <- sf::st_transform(prms_hrus, 5070)

--- a/_targets.R
+++ b/_targets.R
@@ -12,7 +12,11 @@ dir.create("1_fetch/log/", showWarnings = FALSE)
 dir.create("2_process/out/", showWarnings = FALSE)
 dir.create("2_process/log/", showWarnings = FALSE)
 
-# Define dataset of interest for the national geospatial fabric (used to fetch PRMS catchment polygons):
+# Define dataset of interest from the national hydrologic geospatial fabric, NHGF 
+# (used to fetch PRMS catchment polygons); values entered below can take two forms 
+# to indicate preference for the national-scale data ("GeospatialFabric_National.gdb.zip) 
+# or the regional-scale data ("GeospatialFabricFeatures_XX.zip"), where "XX" refers to 
+# the region id/vpu of interest.
 gf_data_select <- 'GeospatialFabric_National.gdb.zip'
 
 # Define which columns related to HRU polygons to keep

--- a/_targets.R
+++ b/_targets.R
@@ -13,7 +13,11 @@ dir.create("2_process/out/", showWarnings = FALSE)
 dir.create("2_process/log/", showWarnings = FALSE)
 
 # Define dataset of interest for the national geospatial fabric (used to fetch PRMS catchment polygons):
-gf_data_select <- 'GeospatialFabricFeatures_02.zip'
+gf_data_select <- 'GeospatialFabric_National.gdb.zip'
+
+# Define which columns related to HRU polygons to keep
+# In national GF, hru_id is identical to hru_id_reg 
+gf_cols_select <- c("hru_id_nat","hru_id","hru_segment","region","Shape_Area")
 
 # Define minor HUCs (hydrologic unit codes) that make up the DRB to use in calls to dataRetrieval functions
 # Lower Delaware: 0204 subregion (for now, exclude New Jersey Coastal (https://water.usgs.gov/GIS/huc_name.html)


### PR DESCRIPTION
Addresses #6 and #5.

We want to retain the attribute `hru_id_nat` for the DRB catchment polygons to make the edited catchments more widely useable. The code changes here incorporate the following changes:

- edit the GF download using `gf_data_select` in `_targets.R` to pull from the national data instead of the regional subset
- make a few formatting changes in `p1_GFv1_catchments_sf` to be more flexible in case a user does want to implement either the regional or national scheme.
- add special handling in `munge_GFv1_catchments` to manually assign values of `hru_id_nat` and `hru_id_reg` for 6 split segments where the catchment polygon has been changed from the original HRU polygon (see #5 for further details).

The edited catchment attributes previously included a column `hru_id` which referred to the regional hru identification number used in NHGF v1.0. That column is retained here, but is now called `hru_id_reg`. Here's a preview of the edited catchments data frame:

```
> tar_load(p2_GFv1_catchments_edited_sf)
> head(p2_GFv1_catchments_edited_sf)
Simple feature collection with 6 features and 7 fields
Geometry type: POLYGON
Dimension:     XY
Bounding box:  xmin: 1712235 ymin: 2307645 xmax: 1746315 ymax: 2349045
Projected CRS: NAD83 / Conus Albers
  PRMS_segid hru_segment hru_id_nat hru_id_reg hru_area_m2 hru_area_km2 region                       geometry
1        1_1           1       6519       4057    31633049       31.633     02 POLYGON ((1745415 2344305, ...
2        1_1           1       6521       4059    32202919       32.203     02 POLYGON ((1743435 2348648, ...
3       10_1          10       6421       3959     3668495        3.668     02 POLYGON ((1715355 2308365, ...
4       10_1          10       6424       3962     1740523        1.741     02 POLYGON ((1714275 2310000, ...
5       11_1          11       6453       3991     1069018        1.069     02 POLYGON ((1733415 2318355, ...
6       11_1          11       6465       4003     4955515        4.956     02 POLYGON ((1732455 2321475, ...
> which(is.na(p2_GFv1_catchments_edited_sf$hru_id_nat))
integer(0)
> which(is.na(p2_GFv1_catchments_edited_sf$hru_id_reg))
integer(0)
```

Note that edits made to `p1_GFv1_catchments_sf` will trigger a rebuild of the crosswalk table when running `tar_make()`. The content of the crosswalk table should not change, but it does mean a potentially long build time (~55 minutes for me):

```
> sum(tar_meta()$seconds, na.rm = TRUE)
[1] 3350.85
> tar_meta(p2_GFv1_catchments_edited_sf)$seconds
[1] 39.61
> tar_meta(p2_prms_nhdv2_xwalk)$seconds
[1] 2355.33
> 
```