### PR TITLE
Fetch nhdv2 catchments for the DRB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ _targets/
 
 #All output
 */out/*
+!1_fetch/out/NHDPlusv2_catchments.gpkg
 !2_process/out/GFv1_NHDv2_xwalk.csv
 !2_process/out/GFv1_catchments_edited.gpkg
 */tmp/*

--- a/1_fetch.R
+++ b/1_fetch.R
@@ -65,6 +65,30 @@ p1_targets_list <- list(
   tar_target(
     p1_nhdv2reaches_sf,
     get_nhdv2_flowlines(drb_huc8s)
+  ),
+  
+  # Download NHDPlusv2 catchments for the DRB
+  tar_target(
+    p1_nhdv2_catchments_sf,
+    {
+      comids <- p1_nhdv2reaches_sf %>%
+        filter(AREASQKM > 0) %>%
+        pull(COMID)
+      get_nhdplusv2_catchments(comids)
+    }
+  ),
+  
+  # Save NHDPlusv2 catchments as a geopackage
+  tar_target(
+    p1_nhdv2_catchments_gpkg,
+    write_sf(p1_nhdv2_catchments_sf,
+             dsn = "1_fetch/out/NHDPlusv2_catchments.gpkg", 
+             layer = "NHDPlusv2_catchments", 
+             driver = "gpkg",
+             quiet = TRUE,
+             # overwrite layer if already exists
+             append = FALSE),
+    format = "file"
   )
   
 )

--- a/1_fetch/src/get_nhdplusv2.R
+++ b/1_fetch/src/get_nhdplusv2.R
@@ -13,8 +13,9 @@ get_nhdv2_flowlines <- function(huc8){
       huc8_basin <- suppressMessages(nhdplusTools::get_huc8(id=x))
       # Create spatial object of huc8 bbox
       huc8_bbox <- sf::st_as_sfc(st_bbox(huc8_basin))
-      # Download NHDPlusV2 flowlines
-      huc8_flines <- suppressMessages(nhdplusTools::get_nhdplus(AOI=huc8_bbox,realization="flowline"))
+      # Download NHDPlusV2 flowlines within each huc8 bbox
+      huc8_flines <- suppressMessages(nhdplusTools::get_nhdplus(AOI=huc8_bbox,
+                                                                realization="flowline"))
     })
   
   # Bind HUC8 flowlines together 
@@ -22,12 +23,31 @@ get_nhdv2_flowlines <- function(huc8){
     bind_rows() %>%
     # Reformat variable names to uppercase
     rename_with(.,toupper,id:enabled) %>%
-    # Remove duplicated COMIDs that result from retrieving flowlines associated with (overlapping) HUC8 bbox's
+    # Remove duplicated COMIDs that result from retrieving flowlines associated 
+    # with (overlapping) HUC8 bbox's
     group_by(COMID) %>%
     slice(1) %>%
-    ungroup()
+    ungroup() %>%
+    # create a new column that uses the REACHCODE attribute to assign
+    # which huc8 sub-basin each flowline reach belongs to
+    mutate(huc8_code = str_sub(REACHCODE, 0, 8))
   
-  return(flines)
+  # Filter flowlines to only include reaches within the basin/watershed of 
+  # interest (as defined by the huc8 codes provided)
+  flines_hucs <- flines %>%
+    filter(huc8_code %in% huc8)
+  
+  # Check whether any other flowlines drain to the target huc8 sub-basins,
+  # even if the reachcode suggests otherwise
+  flines_others <- flines %>%
+    filter(!huc8_code %in% huc8,
+           LEVELPATHI %in% flines_hucs$LEVELPATHI)
+  
+  # Return flowlines
+  flines_out <- bind_rows(flines_hucs, flines_others)
+    
+  return(flines_out)
   
 }
+
 

--- a/1_fetch/src/get_nhdplusv2.R
+++ b/1_fetch/src/get_nhdplusv2.R
@@ -51,3 +51,44 @@ get_nhdv2_flowlines <- function(huc8){
 }
 
 
+
+#' Function to download NHDPlusv2 catchments given a set of COMIDs
+#' 
+#' @param comid character string or vector of character strings containing
+#' the common identifier (COMID or featureid) of the desired catchment(s).
+#' 
+get_nhdplusv2_catchments <- function(comid){
+  
+  # Chunk desired COMIDs into groups, where each group has no more than
+  # 50 COMID's to avoid timeout errors when downloading nhdplus subsets
+  # using helper functions from nhdplusTools
+  comid_df <- tibble(COMID = comid) %>%
+    mutate(comid_n = row_number(),
+           download_grp = ((comid_n -1) %/% 50) + 1)
+  
+  # Download catchments associated with desired COMIDs and return an
+  # sf data frame containing the polygons and value-added attributes.
+  # suppress messages "Found invalid geometry, attempting to fix" from
+  # printing to the console.
+  catchments <- comid_df %>%
+    split(., .$download_grp) %>%
+    lapply(., function(x){
+      cats_sub <- suppressMessages(nhdplusTools::get_nhdplus(comid = x$COMID, 
+                                                             realization = "catchment"))
+    }) %>%
+    bind_rows()
+  
+  # Format variable names
+  catchments_out <- catchments %>%
+    rename_with(., toupper, id:shape_area) %>%
+    rename(COMID = FEATUREID)
+  
+  # Inform user how many catchments were returned
+  message(sprintf("Returning %s catchments of %s total COMID's requested",
+                  format(length(catchments_out$ID), big.mark=","), 
+                  format(length(comid), big.mark=",")))
+  
+  return(catchments_out)
+  
+}
+

--- a/2_process/log/GFv1_data_summary.csv
+++ b/2_process/log/GFv1_data_summary.csv
@@ -1,6 +1,6 @@
 tar_name,filepath,hash
 p1_GFv1_reaches_sf,NA,e22a09007f48d21c
 p1_GFv1_catchments_sf,NA,0f455778db8b949f
-p1_nhdv2reaches_sf,NA,8ab73200b9219ddc
+p1_nhdv2reaches_sf,NA,6347464675dfa8a4
 p2_prms_nhdv2_xwalk,NA,942ab04f0c794a03
 p2_prms_nhdv2_xwalk_csv,2_process/out/GFv1_NHDv2_xwalk.csv,9a20df429b73f841


### PR DESCRIPTION
This PR downloads the NHDPlusV2 catchments for the DRB and saves the catchment polygons as a gpkg file. 

The code changes here include:

- edits to `get_nhdv2_flowlines` to filter the returned NHDv2 flowlines to the DRB
- download the NHDv2 catchments for those filtered COMID's where `AREASQKM > 0`. Zero-area flowlines are included in NHD but do not have associated catchments. They are often "little extensions, sometimes artificial paths (but sometimes still listed as StreamRiver in NHD). Sometimes these are flowlines through a waterbody." _(from #8)_

Closes #17. 